### PR TITLE
0.8.3.3 release to 1.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <antlr.version>3.5.1</antlr.version>
-    <antlr4.version>4.7.2</antlr4.version>
+    <antlr4.version>4.10.1</antlr4.version>
     <jackson.databind.version>2.13.4.1</jackson.databind.version>
     <jackson.version>2.13.2</jackson.version>
     <jsoup.version>1.15.3</jsoup.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>nl.big-o</groupId>
   <artifactId>liqp</artifactId>
   <packaging>jar</packaging>
-  <version>0.8.3.3</version>
+  <version>0.8.3.3-RELEASE</version>
   <name>Liqp</name>
   <description>A Java implementation of the Liquid templating engine backed up by an ANTLR grammar.</description>
   <url>https://github.com/bkiers/Liqp</url>
@@ -19,7 +19,7 @@
     <url>https://github.com/bkiers/Liqp</url>
     <connection>scm:git:git://github.com/bkiers/Liqp.git</connection>
     <developerConnection>scm:git:git@github.com:bkiers/Liqp.git</developerConnection>
-    <tag>0.8.3.3</tag>
+    <tag>0.8.3.3-RELEASE</tag>
   </scm>
 
   <developers>
@@ -101,7 +101,6 @@
       <artifactId>jackson-datatype-jsr310</artifactId>
       <version>${jackson.version}</version>
     </dependency>
-
 
     <dependency>
       <groupId>org.jsoup</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+      <version>1.1.1</version>
+    </dependency>
 
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>nl.big-o</groupId>
   <artifactId>liqp</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.2</version>
+  <version>${liqp.version}</version>
   <name>Liqp</name>
   <description>A Java implementation of the Liquid templating engine backed up by an ANTLR grammar.</description>
   <url>https://github.com/bkiers/Liqp</url>
@@ -19,7 +19,7 @@
     <url>https://github.com/bkiers/Liqp</url>
     <connection>scm:git:git://github.com/bkiers/Liqp.git</connection>
     <developerConnection>scm:git:git@github.com:bkiers/Liqp.git</developerConnection>
-    <tag>1.1.2</tag>
+    <tag>${liqp.version}</tag>
   </scm>
 
   <developers>
@@ -64,7 +64,9 @@
     <jackson.databind.version>2.13.4.1</jackson.databind.version>
     <jackson.version>2.13.2</jackson.version>
     <jsoup.version>1.15.3</jsoup.version>
+    <jsonsimple.version>1.1.1</jsonsimple.version>
     <junit.version>4.13.1</junit.version>
+    <liqp.version>1.1.2</liqp.version>
 
     <main.class />
   </properties>
@@ -123,7 +125,7 @@
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
-      <version>1.1.1</version>
+      <version>${jsonsimple.version}</version>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>nl.big-o</groupId>
   <artifactId>liqp</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.1.2</version>
   <name>Liqp</name>
   <description>A Java implementation of the Liquid templating engine backed up by an ANTLR grammar.</description>
   <url>https://github.com/bkiers/Liqp</url>
@@ -19,7 +19,7 @@
     <url>https://github.com/bkiers/Liqp</url>
     <connection>scm:git:git://github.com/bkiers/Liqp.git</connection>
     <developerConnection>scm:git:git@github.com:bkiers/Liqp.git</developerConnection>
-    <tag>1.1.1-SNAPSHOT</tag>
+    <tag>1.1.2</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>nl.big-o</groupId>
   <artifactId>liqp</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.1.1-SNAPSHOT</version>
   <name>Liqp</name>
   <description>A Java implementation of the Liquid templating engine backed up by an ANTLR grammar.</description>
   <url>https://github.com/bkiers/Liqp</url>
@@ -19,7 +19,7 @@
     <url>https://github.com/bkiers/Liqp</url>
     <connection>scm:git:git://github.com/bkiers/Liqp.git</connection>
     <developerConnection>scm:git:git@github.com:bkiers/Liqp.git</developerConnection>
-    <tag>0.8.3.3-RELEASE</tag>
+    <tag>1.1.1-SNAPSHOT</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>nl.big-o</groupId>
   <artifactId>liqp</artifactId>
   <packaging>jar</packaging>
-  <version>0.8.3.3-RELEASE</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>Liqp</name>
   <description>A Java implementation of the Liquid templating engine backed up by an ANTLR grammar.</description>
   <url>https://github.com/bkiers/Liqp</url>

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -603,7 +603,6 @@ public class Template {
                 String currentResultString = template.render(variables);
                 result.append(currentResultString);
             } catch (Exception exception) {
-                result.append(currentString);
                 System.err.println("Exception occurred while visiting child node: " + exception.getMessage());
             }
         }

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -21,12 +21,6 @@ import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.tree.ParseTree;
 
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.nodes.Node;
-//import org.jsoup.select.NodeVisitor;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -603,44 +603,44 @@ public class Template {
      * @param variables: contains the mapping of the placeholders and is used for
      *                 mapping of the placeholder strings while rendering the input string.
      */
-        public static String processPlaceHolderString(String inputString, Map<String, Object> variables) {
-            StringBuilder result = new StringBuilder();
+    public static String processPlaceHolderString(String inputString, Map<String, Object> variables) {
+        StringBuilder result = new StringBuilder();
 
-            int lastMatchEnd = 0;
-            Matcher matcher = null;
-            Pattern pattern;
+        int lastMatchEnd = 0;
+        Matcher matcher = null;
+        Pattern pattern;
 
-            try {
-                pattern = Pattern.compile("\\{\\{[^{}]*\\}\\}");
-                matcher = pattern.matcher(inputString);
-            } catch (Exception exception) {
-                System.err.println("Returning empty string. Exception occurred while searching for parsing placeholder strings: " + exception.getMessage());
-                return "";
-            }
-
-            // Iterate through matches and modify them
-            while (Objects.nonNull(matcher) && matcher.find()) {
-                try {
-                    result.append(inputString, lastMatchEnd, matcher.start());
-                    String placeholder = matcher.group();
-
-                    Template template = parse(placeholder);
-                    String currentResultString = template.render(variables);
-
-                    result.append(currentResultString);
-                    lastMatchEnd = matcher.end();
-                } catch (Exception exception) {
-                    String emptyString = new String();
-                    result.append(emptyString);
-                    lastMatchEnd = matcher.end();
-                    System.err.println("Exception occurred while searching for parsing placeholder strings: " +
-                            exception.getMessage());
-                }
-            }
-            result.append(inputString.substring(lastMatchEnd));
-
-            return result.toString();
+        try {
+            pattern = Pattern.compile("\\{\\{[^{}]*\\}\\}");
+            matcher = pattern.matcher(inputString);
+        } catch (Exception exception) {
+            System.err.println("Returning empty string. Exception occurred while searching for parsing placeholder strings: " + exception.getMessage());
+            return "";
         }
+
+        // Iterate through matches and modify them
+        while (Objects.nonNull(matcher) && matcher.find()) {
+            try {
+                result.append(inputString, lastMatchEnd, matcher.start());
+                String placeholder = matcher.group();
+
+                Template template = parse(placeholder);
+                String currentResultString = template.render(variables);
+
+                result.append(currentResultString);
+                lastMatchEnd = matcher.end();
+            } catch (Exception exception) {
+                String emptyString = new String();
+                result.append(emptyString);
+                lastMatchEnd = matcher.end();
+                System.err.println("Exception occurred while searching for parsing placeholder strings: " +
+                        exception.getMessage());
+            }
+        }
+        result.append(inputString.substring(lastMatchEnd));
+
+        return result.toString();
+    }
 
 
     // Use toStringTree()

--- a/src/main/java/liqp/Template.java
+++ b/src/main/java/liqp/Template.java
@@ -758,8 +758,6 @@ public class Template {
                 result.append(currentResultString);
                 lastMatchEnd = placeholderMatcher.end();
             } catch (Exception exception) {
-                String emptyString = new String();
-                result.append(emptyString);
                 lastMatchEnd = placeholderMatcher.end();
                 logError("Exception occurred while searching for parsing placeholder strings: ", exception.getMessage());
             }

--- a/src/main/java/liqp/nodes/BlockNode.java
+++ b/src/main/java/liqp/nodes/BlockNode.java
@@ -102,6 +102,9 @@ public class BlockNode implements LNode {
     }
 
     private String getValueAsString(Object value, boolean mapString) {
+        if (Objects.isNull(value)) {
+            return "null";
+        }
         if (value instanceof Map) {
             return mapToString((Map<Object, Object>) value);
         } else if (value instanceof List || value.getClass().isArray()) {
@@ -113,6 +116,9 @@ public class BlockNode implements LNode {
     }
 
     private String getValueWithChecks(Object value) {
+        if (Objects.isNull(value)) {
+            return "null";
+        }
         if (!Objects.isNull(value) && value instanceof String) {
             return "\"" + String.valueOf(value) + "\"";
         }

--- a/src/main/java/liqp/nodes/BlockNode.java
+++ b/src/main/java/liqp/nodes/BlockNode.java
@@ -5,6 +5,8 @@ import liqp.TemplateContext;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static liqp.LValue.BREAK;
 import static liqp.LValue.CONTINUE;
@@ -78,6 +80,19 @@ public class BlockNode implements LNode {
         if (isTemporal(value)) {
             ZonedDateTime time = asTemporal(value, context);
             return rubyDateTimeFormat.format(time);
+        } else {
+            return getValueAsString(value);
+        }
+    }
+    private String mapToString(Map<Object, Object> map) {
+        return map.entrySet().stream()
+                .map(entry -> entry.getKey() + ": " + getValueAsString(entry.getValue()))
+                .collect(Collectors.joining(", ", "{", "}"));
+    }
+
+    private String getValueAsString(Object value) {
+        if (value instanceof Map) {
+            return mapToString((Map<Object, Object>) value);
         } else {
             return String.valueOf(value);
         }

--- a/src/main/java/liqp/nodes/BlockNode.java
+++ b/src/main/java/liqp/nodes/BlockNode.java
@@ -56,11 +56,16 @@ public class BlockNode implements LNode {
             if(value == BREAK || value == CONTINUE) {
                 return value;
             } else if (value instanceof List) {
-                List<Object> list = (List<Object>) value;
-                builder.append(listToString(list));
+                List<?> list = (List<?>) value;
+
+                for (Object obj : list) {
+                    builder.append(asString(obj, context));
+                }
             } else if (value.getClass().isArray()) {
                 Object[] array = (Object[]) value;
-                builder.append(listToString(List.of(array)));
+                for (Object obj : array) {
+                    builder.append(asString(obj, context));
+                }
             } else {
                 builder.append(asString(value, context));
             }

--- a/src/main/java/liqp/nodes/BlockNode.java
+++ b/src/main/java/liqp/nodes/BlockNode.java
@@ -111,21 +111,15 @@ public class BlockNode implements LNode {
     }
 
     private String getValueAsString(Object value) {
-        try {
-            if (Objects.isNull(value)) {
-                return "null";
-            }
-            if (value instanceof Map) {
-                return mapToString((Map<Object, Object>) value);
-            } else if (value instanceof List || value.getClass().isArray()) {
-                return listToString((List<Object>) value);
-            } else {
-                return String.valueOf(value);
-            }
+        if (Objects.isNull(value)) {
+            return "";
         }
-        catch (Exception exception) {
-            System.err.println("Exception occurred converting value to a string. Returning empty string: " + exception.getMessage());
-            return EMPTY_STRING;
+        if (value instanceof Map) {
+            return mapToString((Map<Object, Object>) value);
+        } else if (value instanceof List || value.getClass().isArray()) {
+            return listToString((List<Object>) value);
+        } else {
+            return String.valueOf(value);
         }
     }
 }

--- a/src/test/java/liqp/filters/FilterTest.java
+++ b/src/test/java/liqp/filters/FilterTest.java
@@ -48,7 +48,6 @@ public class FilterTest {
         Template template2 = Template.parse(templateText, defaultSettings);
         try {
             template2.render();
-            fail();
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("no filter available named: |normalize_whitespace"));
         }

--- a/src/test/java/liqp/tags/IncludeTest.java
+++ b/src/test/java/liqp/tags/IncludeTest.java
@@ -1,12 +1,13 @@
 package liqp.tags;
 
 import liqp.*;
-import liqp.exceptions.LiquidException;
 import liqp.exceptions.VariableNotExistException;
 import liqp.filters.Filter;
 import liqp.tags.Include;
 import liqp.parser.Flavor;
 import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -85,7 +86,7 @@ public class IncludeTest {
       assertEquals("ANOTHER", res);
     }
 
-    @Test(expected = LiquidException.class)
+    @Test
     public void renderWithShouldThrowExceptionInJekyll() throws RecognitionException {
 
         Template template = Template.parse("{% include 'color' with 'red' %}",
@@ -99,9 +100,13 @@ public class IncludeTest {
                         .build()
         );
 
-        template.render();
-
-        fail();
+        try {
+            template.render();
+            Assert.assertTrue(true);
+        }
+        catch (Exception exception) {
+            Assert.fail("No exception expected, but caught: " + exception.getMessage());
+        }
     }
 
     @Test
@@ -308,10 +313,10 @@ public class IncludeTest {
         String result = template.render();
 
         // then
-        assertFalse(result.contains("THE_ERROR"));
+        assertTrue(result.contains("THE_ERROR"));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void errorInIncludeCauseMissingIncludeWithCustomRendering() throws IOException {
         //given
         File jekyll = new File(new File("").getAbsolutePath(), "src/test/jekyll");
@@ -320,12 +325,13 @@ public class IncludeTest {
         RenderSettings renderSettings = new RenderSettings.Builder().withShowExceptionsFromInclude(true).build();
         Template template = Template.parse(index, parseSettings).withRenderSettings(renderSettings);
 
-
-        // when
-        template.render();
-
-        // them
-        fail();
+        try {
+            template.render();
+            Assert.assertTrue(true);
+        }
+        catch (Exception exception) {
+            Assert.fail("No exception expected, but caught: " + exception.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
we are making some placeholder handling changes mainly:
1. hashmap parser use "=" but we required ":" as delimiter.
2. if one placeholder fails, we need empty string for that placeholder instead of the thrown exception.